### PR TITLE
Add support for setting timeouts

### DIFF
--- a/pyemvue/auth.py
+++ b/pyemvue/auth.py
@@ -19,10 +19,14 @@ class Auth:
         host: str,
         username: str = None,
         password: str = None,
+        connect_timeout: float = None,
+        read_timeout: float = None,
         tokens: Optional[Dict[str, str]] = None,
         token_updater: Optional[Callable[[Dict[str, str]], None]] = None,
     ):
         self.host = host
+        self.connect_timeout = connect_timeout
+        self.read_timeout = read_timeout
         self.token_updater = token_updater
         # Use pycognito to go through the SRP authentication to get an auth token and refresh token
         self.client = boto3.client(
@@ -82,6 +86,7 @@ class Auth:
 
         return requests.request(
             method, f"{self.host}/{path}", **kwargs, headers=headers,
+            timeout=(self.connect_timeout, self.read_timeout),
         )
 
     def _extract_tokens_from_cognito(self) -> Dict[str, str]:

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -29,10 +29,12 @@ API_MAINTENANCE = 'https://s3.amazonaws.com/com.emporiaenergy.manual.ota/mainten
 
 
 class PyEmVue(object):
-    def __init__(self):
+    def __init__(self, connect_timeout: float = 6.03, read_timeout: float = 10.03):
         self.username = None
         self.token_storage_file = None
         self.customer = None
+        self.connect_timeout = connect_timeout
+        self.read_timeout = read_timeout
 
     def down_for_maintenance(self):
         """Checks to see if the API is down for maintenance, returns the reported message if present."""
@@ -84,7 +86,7 @@ class PyEmVue(object):
         gids = deviceGids
         if isinstance(deviceGids, list):
             gids = '+'.join(map(str, deviceGids))
-        
+
         url = API_DEVICES_USAGE.format(deviceGids=gids, instant=_format_time(instant), scale=scale, unit=unit)
         response = self.auth.request('get', url)
         response.raise_for_status()
@@ -184,8 +186,10 @@ class PyEmVue(object):
 
         self.auth = Auth(
             host=API_ROOT,
-            username=self.username, 
-            password=password, 
+            username=self.username,
+            password=password,
+            connect_timeout=self.connect_timeout,
+            read_timeout=self.read_timeout,
             tokens={
                 'access_token': access_token,
                 'id_token': id_token,


### PR DESCRIPTION
I have noticed several cases in the past few weeks where pyemvue seems to either hang up or wait far too long for API responses. It's not clear if this is caused by an issue on my network or with the Emporia API hanging, but I realized this library does not support setting timeouts.

It is suggested in the Python requests module docs that all requests should have a timeout set, so this PR sets a default connect timeout of 6 seconds and a read timeout of 10 seconds. In my experience, this is more than enough even for very slow Internet connections.

I've tested this with and without the connect/read timeout set on the PyEmVue object as well as setting a very short timeout to confirm everything seems to work fine.