### PR TITLE
Bug39 fix pull

### DIFF
--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -110,7 +110,7 @@ class PyEmVue(object):
                     timestamp = parse(j['deviceListUsages']['instant'])
                     for device in j['deviceListUsages']['devices']:
                         """Sanity Check, number channels returned = number channels configured"""
-                        if (len(device["channelUsages"]) > 1):
+                        if (device["channelUsages"][0].usage) is not None):
                             populated = VueUsageDevice(timestamp=timestamp).from_json_dictionary(device)
                             devices[populated.device_gid] = populated
                             success = True

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -100,7 +100,7 @@ class PyEmVue(object):
         retries = 0
         success = False
         
-        while ((retries <= 10) and (success == false)):
+        while ((retries <= 10) and (success == False)):
             response = self.auth.request('get', url)
             response.raise_for_status()
             devices: dict[int, VueUsageDevice] = {}

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -105,8 +105,7 @@ class PyEmVue(object):
             response.raise_for_status()
             devices: dict[int, VueUsageDevice] = {}
             if response.text:
-                j = response.json()
-            
+                j = response.json()            
                 if 'deviceListUsages' in j and 'devices' in j['deviceListUsages']:
                     timestamp = parse(j['deviceListUsages']['instant'])
                     for device in j['deviceListUsages']['devices']:

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -107,7 +107,7 @@ class PyEmVue(object):
                 timestamp = parse(j['deviceListUsages']['instant'])
                 for device in j['deviceListUsages']['devices']:
                     """Sanity Check, number channels returned = number channels configured"""
-                    if (len(device["channelUsages]")) == deviceInfo[device.deviceGId].channels:
+                    if (len(device["channelUsages"]) == deviceInfo[device.deviceGId].channels):
                         populated = VueUsageDevice(timestamp=timestamp).from_json_dictionary(device)
                         devices[populated.device_gid] = populated
         return devices

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -101,6 +101,9 @@ class PyEmVue(object):
         success = False
         
         while ((retries <= 10) and (success == False)):
+            if (retries > 0):
+                time.sleep(3);
+
             response = self.auth.request('get', url)
             response.raise_for_status()
             devices: dict[int, VueUsageDevice] = {}

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -107,7 +107,7 @@ class PyEmVue(object):
                 timestamp = parse(j['deviceListUsages']['instant'])
                 for device in j['deviceListUsages']['devices']:
                     """Sanity Check, number channels returned = number channels configured"""
-                    if (len(device["channelUsages"]) == deviceInfo[device.deviceGId].channels):
+                    if (len(device["channelUsages"]) > 1:
                         populated = VueUsageDevice(timestamp=timestamp).from_json_dictionary(device)
                         devices[populated.device_gid] = populated
         return devices

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -105,7 +105,7 @@ class PyEmVue(object):
             response.raise_for_status()
             devices: dict[int, VueUsageDevice] = {}
             """Only process response, of 200 (success) response, server fails with 500s (internal server error) from time to time"""
-            if response.status_code != 200:
+            if response.status_code == 200:
                 if response.text:
                     j = response.json()            
                     if 'deviceListUsages' in j and 'devices' in j['deviceListUsages']:

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -102,7 +102,7 @@ class PyEmVue(object):
         success = False
         
         while ((retries <= 5) and (success == False)):
-            if (retries > 0): asyncio.sleep(max(10,(retries*2)));
+            if (retries > 0): asyncio.sleep(max(10,(retries*2)))
             
             response = self.auth.request('get', url)
             devices: dict[int, VueUsageDevice] = {}

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -109,8 +109,8 @@ class PyEmVue(object):
                 if 'deviceListUsages' in j and 'devices' in j['deviceListUsages']:
                     timestamp = parse(j['deviceListUsages']['instant'])
                     for device in j['deviceListUsages']['devices']:
-                        """Sanity Check, number channels returned = number channels configured"""
-                        if (device["channelUsages"][0].usage) is not None):
+                        """Sanity Check, first channel = null = None after parse in python"""
+                        if (j['deviceListUsages']['devices'][0]['channelUsages'][0]['usage'] is not None):
                             populated = VueUsageDevice(timestamp=timestamp).from_json_dictionary(device)
                             devices[populated.device_gid] = populated
                             success = True

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -114,7 +114,6 @@ class PyEmVue(object):
                         timestamp = parse(j['deviceListUsages']['instant'])
                         for device in j['deviceListUsages']['devices']:
                             #Sanity Check, first channel = null = None after parse in python
-                            #2/18/24 - Change check for every device
                             if (device['channelUsages'][0]['usage'] is not None):
                                 populated = VueUsageDevice(timestamp=timestamp).from_json_dictionary(device)
                                 devices[populated.device_gid] = populated

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -120,6 +120,8 @@ class PyEmVue(object):
                                 devices[populated.device_gid] = populated
                                 success = True
                             else:
+                                #clear devices in total, try again, second device backend failed
+                                devices = None;
                                 success = False
                                 retries += 1
                     else:

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -101,8 +101,8 @@ class PyEmVue(object):
         retries = 0
         success = False
         
-        while ((retries <= 10) and (success == False)):
-            if (retries > 0): asyncio.sleep(5)
+        while ((retries <= 5) and (success == False)):
+            if (retries > 0): asyncio.sleep(max(10,retries*2);
             
             response = self.auth.request('get', url)
             devices: dict[int, VueUsageDevice] = {}
@@ -113,8 +113,9 @@ class PyEmVue(object):
                     if 'deviceListUsages' in j and 'devices' in j['deviceListUsages']:
                         timestamp = parse(j['deviceListUsages']['instant'])
                         for device in j['deviceListUsages']['devices']:
-                            """Sanity Check, first channel = null = None after parse in python"""
-                            if (j['deviceListUsages']['devices'][0]['channelUsages'][0]['usage'] is not None):
+                            #Sanity Check, first channel = null = None after parse in python
+                            #2/18/24 - Change check for every device
+                            if (j[device]['channelUsages'][0]['usage'] is not None):
                                 populated = VueUsageDevice(timestamp=timestamp).from_json_dictionary(device)
                                 devices[populated.device_gid] = populated
                                 success = True

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -117,7 +117,7 @@ class PyEmVue(object):
                             success = true
                         else:
                             success = false
-                            retries++
+                            retries +=1
         return devices
 
     def get_chart_usage(self, channel: Union[VueDeviceChannel, VueDeviceChannelUsage], start: Optional[datetime.datetime] = None, end: Optional[datetime.datetime] = None, scale=Scale.SECOND.value, unit=Unit.KWH.value) -> 'tuple[list[float], Optional[datetime.datetime]]':

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -89,7 +89,7 @@ class PyEmVue(object):
         return None
 
 
-    def get_device_list_usage(self, deviceGids: Union[str, 'list[str]'], instant: Optional[datetime.datetime], scale=Scale.SECOND.value, unit=Unit.KWH.value) -> 'dict[int, VueUsageDevice]':
+    async def get_device_list_usage(self, deviceGids: Union[str, 'list[str]'], instant: Optional[datetime.datetime], scale=Scale.SECOND.value, unit=Unit.KWH.value) -> 'dict[int, VueUsageDevice]':
         """Returns a nested dictionary of VueUsageDevice and VueDeviceChannelUsage with the total usage of the devices over the specified scale. Note that you may need to scale this to get a rate (1MIN in kw = 60*result)"""
         if not instant: instant = datetime.datetime.now(datetime.timezone.utc)
         gids = deviceGids

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -2,6 +2,7 @@ from typing import Any, Optional, Union
 import requests
 import datetime
 import json
+import time
 from dateutil.parser import parse
 
 # Our files
@@ -101,6 +102,10 @@ class PyEmVue(object):
         success = False
         
         while ((retries <= 10) and (success == False)):       
+            #Is this correct way to add a delay, blocks thread?   ha python code on its own thread? -DabblerIOT
+            if (retries > 0):
+                time.sleep(2)
+            
             response = self.auth.request('get', url)
             response.raise_for_status()
             devices: dict[int, VueUsageDevice] = {}

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -100,7 +100,7 @@ class PyEmVue(object):
         retries = 0
         success = false
         
-        while ((retries <= 10) && (success == false)):
+        while ((retries <= 10) and (success == false)):
             response = self.auth.request('get', url)
             response.raise_for_status()
             devices: dict[int, VueUsageDevice] = {}

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -105,9 +105,8 @@ class PyEmVue(object):
             if (retries > 0): time.sleep(5)
             
             response = self.auth.request('get', url)
-            response.raise_for_status()
             devices: dict[int, VueUsageDevice] = {}
-            """Only process response, of 200 (success) response, server fails with 500s (internal server error) from time to time"""
+            #Only process response, of 200 (success) response, server fails with 500s (internal server error) from time to time
             if response.status_code == 200:
                 if response.text:
                     j = response.json()            
@@ -128,7 +127,9 @@ class PyEmVue(object):
             else:
                 success = False
                 retries += 1
-                
+        
+        #raise http exception if returned response is in error, ex server 500 error will cause 10 retries, then exception here
+        response.raise_for_status()        
         return devices
 
     def get_chart_usage(self, channel: Union[VueDeviceChannel, VueDeviceChannelUsage], start: Optional[datetime.datetime] = None, end: Optional[datetime.datetime] = None, scale=Scale.SECOND.value, unit=Unit.KWH.value) -> 'tuple[list[float], Optional[datetime.datetime]]':

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -107,7 +107,7 @@ class PyEmVue(object):
                 timestamp = parse(j['deviceListUsages']['instant'])
                 for device in j['deviceListUsages']['devices']:
                     """Sanity Check, number channels returned = number channels configured"""
-                    if (len(device["channelUsages"]) > 1:
+                    if (len(device["channelUsages"]) > 1):
                         populated = VueUsageDevice(timestamp=timestamp).from_json_dictionary(device)
                         devices[populated.device_gid] = populated
         return devices

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -101,10 +101,8 @@ class PyEmVue(object):
         retries = 0
         success = False
         
-        while ((retries <= 10) and (success == False)):       
-            #Is this correct way to add a delay, blocks thread?   ha python code on its own thread? -DabblerIOT
-            if (retries > 0):
-                time.sleep(2)
+        while ((retries <= 10) and (success == False)):
+            if (retries > 0): time.sleep(5)
             
             response = self.auth.request('get', url)
             response.raise_for_status()
@@ -123,7 +121,10 @@ class PyEmVue(object):
                                 success = True
                             else:
                                 success = False
-                                retries +=1
+                                retries += 1
+                    else:
+                        success = False
+                        retries += 1
             else:
                 success = False
                 retries += 1

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -98,7 +98,7 @@ class PyEmVue(object):
         url = API_DEVICES_USAGE.format(deviceGids=gids, instant=_format_time(instant), scale=scale, unit=unit)
         
         retries = 0
-        success = false
+        success = False
         
         while ((retries <= 10) and (success == false)):
             response = self.auth.request('get', url)
@@ -114,9 +114,9 @@ class PyEmVue(object):
                         if (len(device["channelUsages"]) > 1):
                             populated = VueUsageDevice(timestamp=timestamp).from_json_dictionary(device)
                             devices[populated.device_gid] = populated
-                            success = true
+                            success = True
                         else:
-                            success = false
+                            success = False
                             retries +=1
         return devices
 

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -100,10 +100,7 @@ class PyEmVue(object):
         retries = 0
         success = False
         
-        while ((retries <= 10) and (success == False)):
-            if (retries > 0):
-                #time.sleep(3)
-
+        while ((retries <= 10) and (success == False)):       
             response = self.auth.request('get', url)
             response.raise_for_status()
             devices: dict[int, VueUsageDevice] = {}

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -102,7 +102,7 @@ class PyEmVue(object):
         success = False
         
         while ((retries <= 5) and (success == False)):
-            if (retries > 0): asyncio.sleep(max(10,retries*2);
+            if (retries > 0): asyncio.sleep(max(10,retries*2));
             
             response = self.auth.request('get', url)
             devices: dict[int, VueUsageDevice] = {}

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -2,7 +2,7 @@ from typing import Any, Optional, Union
 import requests
 import datetime
 import json
-import asyncio
+import time
 from dateutil.parser import parse
 
 # Our files
@@ -89,7 +89,7 @@ class PyEmVue(object):
         return None
 
 
-    async def get_device_list_usage(self, deviceGids: Union[str, 'list[str]'], instant: Optional[datetime.datetime], scale=Scale.SECOND.value, unit=Unit.KWH.value) -> 'dict[int, VueUsageDevice]':
+    def get_device_list_usage(self, deviceGids: Union[str, 'list[str]'], instant: Optional[datetime.datetime], scale=Scale.SECOND.value, unit=Unit.KWH.value) -> 'dict[int, VueUsageDevice]':
         """Returns a nested dictionary of VueUsageDevice and VueDeviceChannelUsage with the total usage of the devices over the specified scale. Note that you may need to scale this to get a rate (1MIN in kw = 60*result)"""
         if not instant: instant = datetime.datetime.now(datetime.timezone.utc)
         gids = deviceGids
@@ -102,7 +102,8 @@ class PyEmVue(object):
         success = False
         
         while ((retries <= 5) and (success == False)):
-            if (retries > 0): await asyncio.sleep(min(10,(retries*2)))
+            #Is this proper way to delay?   Functions that call this function are async.
+            if (retries > 0): time.sleep(min(10,(retries*2)))
             
             response = self.auth.request('get', url)
             devices: dict[int, VueUsageDevice] = {}

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -124,6 +124,7 @@ class PyEmVue(object):
                                 del devices;
                                 success = False
                                 retries += 1
+                                break
                     else:
                         success = False
                         retries += 1

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -102,13 +102,13 @@ class PyEmVue(object):
         if response.text:
             j = response.json()
             
-            """if 'deviceListUsages' in j and 'devices' in j['deviceListUsages']:  *** this is not right way to get number of devices in total"""
-            timestamp = parse(j['deviceListUsages']['instant'])
-            for device in j['deviceListUsages']['devices']:
-                """Sanity Check, number channels returned = number channels configured"""
-                if (len(device["channelUsages"]) > 1):
-                    populated = VueUsageDevice(timestamp=timestamp).from_json_dictionary(device)
-                    devices[populated.device_gid] = populated
+            if 'deviceListUsages' in j and 'devices' in j['deviceListUsages']:
+                timestamp = parse(j['deviceListUsages']['instant'])
+                for device in j['deviceListUsages']['devices']:
+                    """Sanity Check, number channels returned = number channels configured"""
+                    if (len(device["channelUsages"]) > 1):
+                        populated = VueUsageDevice(timestamp=timestamp).from_json_dictionary(device)
+                        devices[populated.device_gid] = populated
         return devices
 
     def get_chart_usage(self, channel: Union[VueDeviceChannel, VueDeviceChannelUsage], start: Optional[datetime.datetime] = None, end: Optional[datetime.datetime] = None, scale=Scale.SECOND.value, unit=Unit.KWH.value) -> 'tuple[list[float], Optional[datetime.datetime]]':

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -102,7 +102,7 @@ class PyEmVue(object):
         success = False
         
         while ((retries <= 5) and (success == False)):
-            if (retries > 0): asyncio.sleep(max(10,(retries*2)))
+            if (retries > 0): asyncio.sleep(min(10,(retries*2)))
             
             response = self.auth.request('get', url)
             devices: dict[int, VueUsageDevice] = {}
@@ -121,7 +121,7 @@ class PyEmVue(object):
                                 success = True
                             else:
                                 #clear devices in total, try again, second device backend failed
-                                del devices;
+                                del devices
                                 success = False
                                 retries += 1
                                 break

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -102,7 +102,7 @@ class PyEmVue(object):
         
         while ((retries <= 10) and (success == False)):
             if (retries > 0):
-                time.sleep(3);
+                #time.sleep(3)
 
             response = self.auth.request('get', url)
             response.raise_for_status()

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -2,7 +2,7 @@ from typing import Any, Optional, Union
 import requests
 import datetime
 import json
-import asyncio
+import time
 from dateutil.parser import parse
 
 # Our files
@@ -102,7 +102,7 @@ class PyEmVue(object):
         success = False
         
         while ((retries <= 5) and (success == False)):
-            if (retries > 0): asyncio.sleep(min(10,(retries*2)))
+            if (retries > 0): time.sleep(min(10,(retries*2)))
             
             response = self.auth.request('get', url)
             devices: dict[int, VueUsageDevice] = {}

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -114,12 +114,19 @@ class PyEmVue(object):
                         timestamp = parse(j['deviceListUsages']['instant'])
                         for device in j['deviceListUsages']['devices']:
                             #Sanity Check, first channel = null = None after parse in python
-                            if (device['channelUsages'][0]['usage'] is not None):
-                                populated = VueUsageDevice(timestamp=timestamp).from_json_dictionary(device)
-                                devices[populated.device_gid] = populated
-                                success = True
+                            if 'channelUsages' in device:
+                                channelUsage = device['channelUsages'][0]
+                                if 'usage' in channelUsage and (channelUsage['usage'] is not None):
+                                    populated = VueUsageDevice(timestamp=timestamp).from_json_dictionary(device)
+                                    devices[populated.device_gid] = populated
+                                    success = True
+                                else:
+                                    #clear devices in total, try again, second device backend failed
+                                    del devices
+                                    success = False
+                                    retries += 1
+                                    break
                             else:
-                                #clear devices in total, try again, second device backend failed
                                 del devices
                                 success = False
                                 retries += 1

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -2,7 +2,7 @@ from typing import Any, Optional, Union
 import requests
 import datetime
 import json
-import time
+import asyncio
 from dateutil.parser import parse
 
 # Our files
@@ -102,7 +102,7 @@ class PyEmVue(object):
         success = False
         
         while ((retries <= 10) and (success == False)):
-            if (retries > 0): time.sleep(5)
+            if (retries > 0): asyncio.sleep(5)
             
             response = self.auth.request('get', url)
             devices: dict[int, VueUsageDevice] = {}

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -101,15 +101,14 @@ class PyEmVue(object):
         devices: dict[int, VueUsageDevice] = {}
         if response.text:
             j = response.json()
-            """Sanity Check, number devices returned = number devices requested"""
-            if (len(j["deviceListUsages"]["devices"]) == len(gids)):
-                """if 'deviceListUsages' in j and 'devices' in j['deviceListUsages']:  *** this is not right way to get number of devices in total"""
-                timestamp = parse(j['deviceListUsages']['instant'])
-                for device in j['deviceListUsages']['devices']:
-                    """Sanity Check, number channels returned = number channels configured"""
-                    if (len(device["channelUsages"]) > 1):
-                        populated = VueUsageDevice(timestamp=timestamp).from_json_dictionary(device)
-                        devices[populated.device_gid] = populated
+            
+            """if 'deviceListUsages' in j and 'devices' in j['deviceListUsages']:  *** this is not right way to get number of devices in total"""
+            timestamp = parse(j['deviceListUsages']['instant'])
+            for device in j['deviceListUsages']['devices']:
+                """Sanity Check, number channels returned = number channels configured"""
+                if (len(device["channelUsages"]) > 1):
+                    populated = VueUsageDevice(timestamp=timestamp).from_json_dictionary(device)
+                    devices[populated.device_gid] = populated
         return devices
 
     def get_chart_usage(self, channel: Union[VueDeviceChannel, VueDeviceChannelUsage], start: Optional[datetime.datetime] = None, end: Optional[datetime.datetime] = None, scale=Scale.SECOND.value, unit=Unit.KWH.value) -> 'tuple[list[float], Optional[datetime.datetime]]':

--- a/pyemvue/pyemvue.py
+++ b/pyemvue/pyemvue.py
@@ -102,7 +102,7 @@ class PyEmVue(object):
         success = False
         
         while ((retries <= 5) and (success == False)):
-            if (retries > 0): asyncio.sleep(max(10,retries*2));
+            if (retries > 0): asyncio.sleep(max(10,(retries*2)));
             
             response = self.auth.request('get', url)
             devices: dict[int, VueUsageDevice] = {}
@@ -115,13 +115,13 @@ class PyEmVue(object):
                         for device in j['deviceListUsages']['devices']:
                             #Sanity Check, first channel = null = None after parse in python
                             #2/18/24 - Change check for every device
-                            if (j[device]['channelUsages'][0]['usage'] is not None):
+                            if (device['channelUsages'][0]['usage'] is not None):
                                 populated = VueUsageDevice(timestamp=timestamp).from_json_dictionary(device)
                                 devices[populated.device_gid] = populated
                                 success = True
                             else:
                                 #clear devices in total, try again, second device backend failed
-                                devices = None;
+                                del devices;
                                 success = False
                                 retries += 1
                     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.25"
+version = "0.18.26"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.7"
+version = "0.18.8"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.19"
+version = "0.18.20"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.6"
+version = "0.18.7"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.20"
+version = "0.18.21"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.32"
+version = "0.18.33"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.15"
+version = "0.18.16"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.10"
+version = "0.18.11"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.17"
+version = "0.18.18"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.8"
+version = "0.18.9"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.14"
+version = "0.18.15"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.31"
+version = "0.18.32"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.9"
+version = "0.18.10"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.12"
+version = "0.18.13"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.23"
+version = "0.18.24"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.30"
+version = "0.18.31"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.34"
+version = "0.18.35"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.35"
+version = "0.18.36"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.21"
+version = "0.18.22"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.24"
+version = "0.18.25"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.29"
+version = "0.18.30"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.33"
+version = "0.18.34"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.26"
+version = "0.18.27"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.13"
+version = "0.18.14"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.18"
+version = "0.18.19"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.28"
+version = "0.18.29"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.16"
+version = "0.18.17"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.22"
+version = "0.18.23"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.11"
+version = "0.18.12"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyemvue"
-version = "0.18.27"
+version = "0.18.28"
 authors = [
   { name="magico13", email="magico1313@gmail.com" },
 ]


### PR DESCRIPTION
Caught different ways api was failing and coded retries.   Retries should be here instead of in ha code for others using pyemvue.  One possible issue with changes are we need a delay here (to try to give enough delay if api bounces their web server or backend server, to give it time to restart).   Saw once or twice I think, needs about 20-30 seconds before server will start returning valid responses again.   The more devices on account (fetched with one request), the more chance of having an issue.   Problem with code being in a non async function we can't define an asyncio.sleep..  concerned that the delay time may block all for delay time (normally just 2 seconds) if 1 retry.

[badapiresponseseconddevicenull.txt](https://github.com/magico13/PyEmVue/files/14380674/badapiresponseseconddevicenull.txt)
[badapiresponse.txt](https://github.com/magico13/PyEmVue/files/14380676/badapiresponse.txt)
[goodapiresponse.txt](https://github.com/magico13/PyEmVue/files/14380678/goodapiresponse.txt)

Running before changes many (5-10) 0s and unknowns a day.   Running now, clean data (2 days run).

Sorry for so many commits, sorting out python again, and how git works with ha and syntax for importing forked versions.   (Docker containers have my head spinning still).  :). I seemed to have to increment version number to have ha redownload it on restart.  (Still figuring things out.)

http error handling was moved around so we retry on http errors instead of kicking error back to caller.   If last response is an http error we will return an error still (just like before).   Let's see if I did this request correctly.  :).  

Cheers. 

Changes are just in pyemvue around line 100.  Please review.